### PR TITLE
Fixed game crash when EGG attempts to puppet SWA.

### DIFF
--- a/common/decisions/EGG_decisions.txt
+++ b/common/decisions/EGG_decisions.txt
@@ -2976,10 +2976,10 @@ EGG_DEL_CREATION = {
 					#SWA = {
 					#	transfer_state = PREV
 					#}
-				}
-				delete_unit = {
-					state = THIS
-					disband = yes
+					delete_unit = {
+						state = THIS
+						disband = yes
+					}
 				}
 			}
 			

--- a/history/states/743-Ilaichi.txt
+++ b/history/states/743-Ilaichi.txt
@@ -5,7 +5,7 @@ state={
 		522 526 572 590 606 617 
 	}
 	history={
-		owner = BHA
+		owner = SWA
 		buildings = {
 
 		}

--- a/history/states/773-Mav-es-Rinda.txt
+++ b/history/states/773-Mav-es-Rinda.txt
@@ -7,9 +7,9 @@ state={
 	manpower=21234
 	state_category = enclave	
 	history={
-		#owner = SWA
+		owner = SWA
 		
-		#add_core_of = BHA
+		add_core_of = BHA
 		buildings = {
 			infrastructure = 5
 			844 = {

--- a/history/states/774-Dar-es-Malayali.txt
+++ b/history/states/774-Dar-es-Malayali.txt
@@ -7,7 +7,7 @@ state={
 	manpower=202334	
        state_category = town
 	history={
-		#owner = SWA
+		owner = SWA
                  buildings = {
 		infrastructure = 5
          778= {          
@@ -16,7 +16,7 @@ state={
                 
            }
 		
-		#add_core_of = BHA
+		add_core_of = BHA
                   victory_points = {
 			778 5
 		}

--- a/map/supplyareas/250-SupplyArea.txt
+++ b/map/supplyareas/250-SupplyArea.txt
@@ -3,6 +3,6 @@ supply_area={
 	name="SUPPLYAREA_250"
 	value=10
 	states={
-		775
+		775 774 773
 	}
 }


### PR DESCRIPTION
Seems like absence of supply areas for several SWA states caused the exception on chunks recreation. The problem can be located by checking error.log file for following king of strings:

> `[03:18:27][gamestate.cpp:2310]: The state 773 - ÐÐ°Ð²-ÐµÑ-Ð ÐžÐœÐŽÐ° has no supply area.`

@Mistfader Check & merge it into your branch.